### PR TITLE
Don't set main to gulpfile.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,5 @@
     "run-sequence": "^1.2.1",
     "systemjs-builder": "^0.16.3",
     "typescript": "^3.0.0"
-  },
-  "main": "gulpfile.js"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-angular-adal",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Use Azure AD Library - ADAL in Angular 7.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Setting main to gulpfile.js messes up compilation of angular projects that use this library.